### PR TITLE
Profile work

### DIFF
--- a/src/azure-cli-core/azure/cli/core/profiles/_shared.py
+++ b/src/azure-cli-core/azure/cli/core/profiles/_shared.py
@@ -32,10 +32,7 @@ class CustomResourceType(object):  # pylint: disable=too-few-public-methods
 
 class ResourceType(Enum):  # pylint: disable=too-few-public-methods
 
-    MGMT_ACS = ('azure.mgmt.containerservice', 'ContainerServiceClient')
-    MGMT_AKS = ('azure.mgmt.containerservice', 'ContainerServiceClient')
-    MGMT_AKS_PREVIEW = ('azure.mgmt.containerservice', 'ContainerServiceClient')
-    MGMT_OSA = ('azure.mgmt.containerservice', 'ContainerServiceClient')
+    MGMT_CONTAINERSERVICE = ('azure.mgmt.containerservice', 'ContainerServiceClient')
     MGMT_KEYVAULT = ('azure.mgmt.keyvault', 'KeyVaultManagementClient')
     MGMT_STORAGE = ('azure.mgmt.storage', 'StorageManagementClient')
     MGMT_COMPUTE = ('azure.mgmt.compute', 'ComputeManagementClient')
@@ -83,10 +80,11 @@ class SDKProfile(object):  # pylint: disable=too-few-public-methods
 
 AZURE_API_PROFILES = {
     'latest': {
-        ResourceType.MGMT_ACS: '2017-07-01', # Microsoft.ContainerService / ACS
-        ResourceType.MGMT_AKS: '2018-03-31', # Microsoft.ContainerService / AKS
-        ResourceType.MGMT_AKS_PREVIEW: '2018-08-01-preview', # Microsoft.ContainerService / AKS
-        ResourceType.MGMT_OSA: '2018-09-30-preview', # Microsoft.ContainerService / OSA
+        ResourceType.MGMT_CONTAINERSERVICE: SDKProfile('2018-03-31', {
+            'container_services': '2017-07-01',
+            'managed_clusters': '2018-08-01-preview',
+            'open_shift_managed_clusters': '2018-09-30-preview'
+        }),
         ResourceType.MGMT_STORAGE: '2018-07-01',
         ResourceType.MGMT_NETWORK: '2018-10-01',
         ResourceType.MGMT_COMPUTE: SDKProfile('2018-10-01', {

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/__init__.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/__init__.py
@@ -18,7 +18,8 @@ class ContainerServiceCommandsLoader(AzCommandsLoader):
         super(ContainerServiceCommandsLoader, self).__init__(cli_ctx=cli_ctx,
                                                              custom_command_type=acs_custom,
                                                              min_profile='2017-03-10-profile',
-                                                             resource_type=ResourceType.MGMT_ACS)
+                                                             resource_type=ResourceType.MGMT_CONTAINERSERVICE,
+                                                             operation_group='container_services')
 
     def load_command_table(self, args):
         from azure.cli.command_modules.acs.commands import load_command_table

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/commands.py
@@ -28,8 +28,7 @@ def load_command_table(self, _):
 
     managed_clusters_sdk = CliCommandType(
         operations_tmpl='azure.mgmt.containerservice.operations.managed_clusters_operations#ManagedClustersOperations.{}',
-        client_factory=cf_managed_clusters,
-        resource_type=ResourceType.MGMT_AKS
+        client_factory=cf_managed_clusters
     )
 
     managed_clusters_preview_sdk = CliCommandType(
@@ -61,19 +60,19 @@ def load_command_table(self, _):
         g.show_command('show', 'get')
         g.wait_command('wait')
 
-    # # ACS Mesos DC/OS commands
+    # ACS Mesos DC/OS commands
     with self.command_group('acs dcos', container_services_sdk) as g:
         g.custom_command('browse', 'dcos_browse')
         g.custom_command('install-cli', 'dcos_install_cli', client_factory=None)
 
-    # # ACS Kubernetes commands
+    # ACS Kubernetes commands
     with self.command_group('acs kubernetes', container_services_sdk) as g:
         g.custom_command('browse', 'k8s_browse')
         g.custom_command('get-credentials', 'k8s_get_credentials')
         g.custom_command('install-cli', 'k8s_install_cli', client_factory=None)
 
     # AKS commands
-    with self.command_group('aks', managed_clusters_sdk, resource_type=ResourceType.MGMT_AKS) as g:
+    with self.command_group('aks', managed_clusters_sdk, operation_group='managed_clusters') as g:
         g.custom_command('browse', 'aks_browse')
         g.custom_command('create', 'aks_create', supports_no_wait=True)
         g.command('delete', 'delete', supports_no_wait=True, confirmation=True)
@@ -100,7 +99,7 @@ def load_command_table(self, _):
         g.custom_command('get-versions', 'aks_get_versions', table_transformer=aks_versions_table_format)
 
     # OSA commands
-    with self.command_group('openshift', openshift_managed_clusters_sdk, resource_type=ResourceType.MGMT_OSA) as g:
+    with self.command_group('openshift', openshift_managed_clusters_sdk, operation_group='open_shift_managed_clusters') as g:
         g.custom_command('create', 'openshift_create', supports_no_wait=True)
         g.command('delete', 'delete', supports_no_wait=True, confirmation=True)
         g.custom_command('scale', 'openshift_scale', supports_no_wait=True)

--- a/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
+++ b/src/command_modules/azure-cli-acs/azure/cli/command_modules/acs/custom.py
@@ -1453,12 +1453,12 @@ def aks_create(cmd, resource_group_name, name, ssh_key_value,  # pylint: disable
                generate_ssh_keys=False,  # pylint: disable=unused-argument
                no_wait=False):
                
-    ManagedClusterAgentPoolProfile, ManagedClusterAADProfile = cmd.get_models('ManagedClusterAgentPoolProfile', 'ManagedClusterAADProfile', resource_type=ResourceType.MGMT_AKS_PREVIEW)
+    ManagedClusterAgentPoolProfile, ManagedClusterAADProfile = cmd.get_models('ManagedClusterAgentPoolProfile', 'ManagedClusterAADProfile')
     ContainerServiceSshConfiguration, ContainerServiceSshPublicKey = cmd.get_models(
         'ContainerServiceSshConfiguration', 'ContainerServiceSshPublicKey')
     ContainerServiceLinuxProfile, ContainerServiceServicePrincipalProfile, ContainerServiceNetworkProfile, ContainerServiceStorageProfileTypes = cmd.get_models(
         'ContainerServiceLinuxProfile', 'ContainerServiceServicePrincipalProfile', 'ContainerServiceNetworkProfile', 'ContainerServiceStorageProfileTypes')
-    ManagedCluster = cmd.get_models('ManagedCluster', resource_type=ResourceType.MGMT_AKS_PREVIEW)
+    ManagedCluster = cmd.get_models('ManagedCluster')
 
     _validate_ssh_key(no_ssh_key, ssh_key_value)
 


### PR DESCRIPTION
This seems to be working for me.  I eliminated the distinction between AKS and AKS preview and just put the 'managed_cluster' version as the preview version. Anything that is in the non-preview version *should* be also in the preview version. However, we may need to set something up to further understand the distinctions here. 